### PR TITLE
Cherry-pick extension point for rdseffswitch extension

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/plugin.xml
+++ b/bundles/org.palladiosimulator.simulizar/plugin.xml
@@ -8,6 +8,7 @@
    <extension-point id="org.palladiosimulator.simulizar.configurator" name="SimuLizar Workflow Configuration Customization" schema="schema/org.palladiosimulator.simulizar.configurator.exsd"/>
    <extension-point id="org.palladiosimulator.simulizar.modelobserver" name="Simulizar Model Observer" schema="schema/org.palladiosimulator.simulizar.modelobserver.exsd"/>
    <extension-point id="org.palladiosimulator.simulizar.reconfigurationloader" name="Reconfiguration loader" schema="schema/org.palladiosimulator.simulizar.reconfigurationloader.exsd"/>
+   <extension-point id="org.palladiosimulator.simulizar.interpreter.rdseffswitch" name="RDSeff Switch" schema="schema/org.palladiosimulator.simulizar.interpreter.rdseffswitch.exsd"/>
 	   <extension
          point="org.palladiosimulator.simulizar.modelobserver">
       <modelObserver

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RDSeffSwitch.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RDSeffSwitch.java
@@ -9,6 +9,8 @@ import java.util.Stack;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.ComposedSwitch;
+import org.eclipse.emf.ecore.util.Switch;
 import org.palladiosimulator.analyzer.completions.DelegatingExternalCallAction;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
@@ -61,11 +63,12 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
  * @author Joachim Meyer, Steffen Becker, Sebastian Lehrig
  *
  */
-class RDSeffSwitch extends SeffSwitch<Object> {
+class RDSeffSwitch extends SeffSwitch<Object> implements IComposableSwitch {
 
     private static final Boolean SUCCESS = true;
-
     private static final Logger LOGGER = Logger.getLogger(RDSeffSwitch.class);
+
+    private ComposedSwitch<Object> parentSwitch;
     private final TransitionDeterminer transitionDeterminer;
     private final InterpreterDefaultContext context;
     private final Allocation allocation;
@@ -77,12 +80,10 @@ class RDSeffSwitch extends SeffSwitch<Object> {
     /**
      * Constructor.
      *
+     * @param context
+     *            Default context for the pcm interpreter.
      * @param basicComponentInstance
-     *
-     * @param modelInterpreter
-     *            the corresponding pcm model interpreter holding this switch.
-     * @param assemblyContext
-     *            the assembly context of the component of the SEFF.
+     *            Simulated component
      */
     public RDSeffSwitch(final InterpreterDefaultContext context,
             final SimulatedBasicComponentInstance basicComponentInstance) {
@@ -92,6 +93,23 @@ class RDSeffSwitch extends SeffSwitch<Object> {
         this.transitionDeterminer = new TransitionDeterminer(context);
         this.resultStackFrame = new SimulatedStackframe<Object>();
         this.basicComponentInstance = basicComponentInstance;
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param context
+     *				Default context for the pcm interpreter.
+     * @param basicComponentInstance
+     *				Simulated component
+     * @param parentSwitch
+     *				The composed switch which is containing this switch
+     */
+    public RDSeffSwitch(final InterpreterDefaultContext context,
+            final SimulatedBasicComponentInstance basicComponentInstance, ComposedSwitch<Object> parentSwitch) {
+    	this(context, basicComponentInstance);
+    	this.parentSwitch = parentSwitch;
     }
 
     /**
@@ -120,7 +138,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
                 LOGGER.debug("Interpret " + currentAction.eClass().getName() + ": " + currentAction);
             }
             this.firePassedEvent(currentAction, EventType.BEGIN);
-            this.doSwitch(currentAction);
+            this.getParentSwitch().doSwitch(currentAction);
             this.firePassedEvent(currentAction, EventType.END);
             currentAction = currentAction.getSuccessor_AbstractAction();
         }
@@ -271,7 +289,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
             LOGGER.error("No branch's condition evaluated to true, no branch selected: " + object);
             throw new PCMModelInterpreterException("No branch transition was active. This is not allowed.");
         } else {
-            this.doSwitch(branchTransition.getBranchBehaviour_BranchTransition());
+            this.getParentSwitch().doSwitch(branchTransition.getBranchBehaviour_BranchTransition());
         }
 
         return SUCCESS;
@@ -487,6 +505,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
                         LOGGER.debug("Created new RDSeff interpreter for " + ((this.isAsync()) ? "asynced" : "synced")
                                 + " forked baviour: " + this);
                     }
+                    // no use of parentSwitch.doSwitch() because we want the inner switches
                     seffInterpreter.doSwitch(forkedBehaviour);
                 }
 
@@ -508,7 +527,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Interpret loop number " + i + ": " + object);
             }
-            this.doSwitch(object.getBodyBehaviour_Loop());
+            this.getParentSwitch().doSwitch(object.getBodyBehaviour_Loop());
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Finished loop number " + i + ": " + object);
             }
@@ -520,7 +539,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
      *
      * @param object
      *            the CollectionIteratorAction.
-     * @param parameterthe
+     * @param parameter
      *            parameter of the collection.
      * @return
      */
@@ -566,7 +585,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
              * within an iteration.
              */
 
-            this.doSwitch(object.getBodyBehaviour_Loop());
+            this.getParentSwitch().doSwitch(object.getBodyBehaviour_Loop());
 
             // remove stack frame for value characterisations of inner
             // collection variable
@@ -587,6 +606,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
 
     /**
      * @param internalAction
+     * 				The internal action containing the resource demand
      */
     private void interpretResourceDemands(final InternalAction internalAction) {
         final AllocationContext allocationContext = this.getAllocationContext(this.allocation);
@@ -607,6 +627,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
 
         }
     }
+
 
     /**
      * @param internalAction
@@ -652,6 +673,7 @@ class RDSeffSwitch extends SeffSwitch<Object> {
         }
     }
 
+
     /**
      * Gets the allocation context for the current assembly context stack. The stack is investigated
      * in a FIFO-manner, i.e., first upper elements are checked. This is needed for the case of sub
@@ -679,4 +701,14 @@ class RDSeffSwitch extends SeffSwitch<Object> {
         throw new PCMModelAccessException("No AllocationContext in Allocation " + allocation + " for AssemblyContext "
                 + this.context.getAssemblyContextStack().peek() + " or its parents.");
     }
+
+
+	@Override
+	public Switch<Object> getParentSwitch() {
+		if (this.parentSwitch != null) {
+			return this.parentSwitch;
+		}
+
+		return this;
+	}
 }

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RepositoryComponentSwitch.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RepositoryComponentSwitch.java
@@ -215,7 +215,7 @@ class RepositoryComponentSwitch extends RepositorySwitch<SimulatedStackframe<Obj
             
             final List<AbstractRDSeffSwitchFactory> switchFactories = ExtensionHelper
             		.getExecutableExtensions(RDSEFFSWITCH_EXTENSION_POINT_ID, RDSEFFSWITCH_EXTENSION_ATTRIBUTE);
-            final  ComposedSwitch<Object> interpreter = new ComposedSwitch<Object>();
+            final  ExplicitDispatchComposedSwitch<Object> interpreter = new ExplicitDispatchComposedSwitch<Object>();
             switchFactories.stream().forEach(s -> interpreter.addSwitch(
             		s.createRDSeffSwitch(this.context, basicComponentInstance, interpreter)));
             // add default RDSeffSwitch

--- a/org.palladiosimulator.simulizar/schema/org.palladiosimulator.simulizar.interpreter.rdseffswitch.exsd
+++ b/org.palladiosimulator.simulizar/schema/org.palladiosimulator.simulizar.interpreter.rdseffswitch.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.palladiosimulator.simulizar" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.palladiosimulator.simulizar" id="org.palladiosimulator.simulizar.interpreter.rdseffswitch" name="RDSeff Switch Factory"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="rdseffswitch"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="rdseffswitch">
+      <complexType>
+         <attribute name="rdseffswitch" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.palladiosimulator.simulizar.interpreter.AbstractRDSeffSwitchFactory:"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.palladiosimulator.simulizar/schema/org.palladiosimulator.simulizar.interpreter.rdseffswitch.exsd
+++ b/org.palladiosimulator.simulizar/schema/org.palladiosimulator.simulizar.interpreter.rdseffswitch.exsd
@@ -6,7 +6,8 @@
          <meta.schema plugin="org.palladiosimulator.simulizar" id="org.palladiosimulator.simulizar.interpreter.rdseffswitch" name="RDSeff Switch Factory"/>
       </appinfo>
       <documentation>
-         [Enter description of this extension point.]
+         Extension Point to add the interpretation of new PCM model elements to the RDSeffSwitch.
+         Use-Case: Plugin extends PCM and these new objects should be interpreted by SimuLizar.
       </documentation>
    </annotation>
 
@@ -23,21 +24,21 @@
          <attribute name="point" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  Point of extension point.
                </documentation>
             </annotation>
          </attribute>
          <attribute name="id" type="string">
             <annotation>
                <documentation>
-                  
+                   ID of extension point.
                </documentation>
             </annotation>
          </attribute>
          <attribute name="name" type="string">
             <annotation>
                <documentation>
-                  
+                    Name of extension point.
                </documentation>
                <appinfo>
                   <meta.attribute translatable="true"/>
@@ -52,7 +53,8 @@
          <attribute name="rdseffswitch" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  Factory class that creates a switch for the new PCM object.
+                  This switch is used by SimuLizar to interpret the object.
                </documentation>
                <appinfo>
                   <meta.attribute kind="java" basedOn="org.palladiosimulator.simulizar.interpreter.AbstractRDSeffSwitchFactory:"/>

--- a/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/AbstractRDSeffSwitchFactory.java
+++ b/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/AbstractRDSeffSwitchFactory.java
@@ -1,0 +1,27 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import org.eclipse.emf.ecore.util.ComposedSwitch;
+import org.eclipse.emf.ecore.util.Switch;
+import org.palladiosimulator.simulizar.runtimestate.SimulatedBasicComponentInstance;
+
+/**
+ * Abstract Factory used by the extensible behaviour switches extension point.
+ * 
+ * @author mrombach
+ *
+ */
+public abstract class AbstractRDSeffSwitchFactory {
+	
+	/**
+	 * 
+     * @param context
+     *				Default context for the pcm interpreter.
+     * @param basicComponentInstance
+     *				Simulated component
+     * @param parentSwitch
+     *				The composed switch which is containing the created switch
+	 * @return a composable switch
+	 */
+	protected abstract Switch<Object> createRDSeffSwitch(final InterpreterDefaultContext context,
+            final SimulatedBasicComponentInstance basicComponentInstance, ComposedSwitch<Object> parentSwitch);
+}

--- a/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/AbstractRDSeffSwitchFactory.java
+++ b/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/AbstractRDSeffSwitchFactory.java
@@ -23,5 +23,5 @@ public abstract class AbstractRDSeffSwitchFactory {
 	 * @return a composable switch
 	 */
 	protected abstract Switch<Object> createRDSeffSwitch(final InterpreterDefaultContext context,
-            final SimulatedBasicComponentInstance basicComponentInstance, ComposedSwitch<Object> parentSwitch);
+            final SimulatedBasicComponentInstance basicComponentInstance, ExplicitDispatchComposedSwitch<Object> parentSwitch);
 }

--- a/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/ExplicitDispatchComposedSwitch.java
+++ b/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/ExplicitDispatchComposedSwitch.java
@@ -1,0 +1,16 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.ComposedSwitch;
+
+public class ExplicitDispatchComposedSwitch<T> extends ComposedSwitch<T> {
+
+	@Override
+	public T doSwitch(EClass theEClass, EObject theEObject) {
+		return super.doSwitch(theEClass, theEObject);
+	}
+	
+	
+
+}

--- a/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/IComposableSwitch.java
+++ b/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/IComposableSwitch.java
@@ -1,0 +1,17 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import org.eclipse.emf.ecore.util.Switch;
+
+/**
+ * Interface for a switch which is able to composed together with other switches.
+ * 
+ * @author Matthias Rombach
+ *
+ */
+public interface IComposableSwitch {
+	
+	/**
+	 * @return the ComposedSwitch containing the implementing switch or any other switch preferred for the doSwitch
+	 */
+	public Switch<Object> getParentSwitch();
+}


### PR DESCRIPTION
Enables us to extend the rdseff switch using extension points.

Cherry-picked from: [ExtensibleBehaviourSwitches](https://github.com/PalladioSimulator/Palladio-Analyzer-SimuLizar/tree/ExtensibleBehaviourSwitches)

Jira: [SIMULIZAR-90](https://sdqbuild.ipd.kit.edu/jira/projects/SIMULIZAR/issues/SIMULIZAR-90)
