### PR TITLE
Added dependency to DesmoJ feature to fix test dependencies.

### DIFF
--- a/releng/org.palladiosimulator.simulizar.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.simulizar.targetplatform/tp.target
@@ -110,11 +110,11 @@
 		</location>
 		
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="de.uka.ipd.sdq.simulation.abstractsimengine.feature.feature.group" version="tbd"/>
+			<unit id="org.palladiosimulator.simulation.abstractsimengine.desmoj.feature.feature.group" version="tbd"/>
 			<repository location="https://sdqweb.ipd.kit.edu/eclipse/abstractsimengine/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-			<unit id="de.uka.ipd.sdq.simulation.abstractsimengine.feature.feature.group" version="tbd"/>
+			<unit id="org.palladiosimulator.simulation.abstractsimengine.desmoj.feature.feature.group" version="tbd"/>
 			<repository location="https://sdqweb.ipd.kit.edu/eclipse/abstractsimengine/nightly/"/>
 		</location>
 		


### PR DESCRIPTION
This PR fixes an issue introduces by changes of PalladioSimulator/Palladio-Simulation-AbstractSimEngine#1. While Simulizar only depends on the abstract simulation engine, the tests need a concrete engine in order to be executable. I added a dependency to the DesmoJ engine, which was the default before the change.