### PR TITLE
Make closed workload reconfigurable

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/UsageModelSyncer.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/UsageModelSyncer.java
@@ -49,12 +49,17 @@ public class UsageModelSyncer extends AbstractUsageModelObserver {
 
     @Override
     protected void set(final Notification notification) {
-        if (UsagemodelPackage.eINSTANCE.getClosedWorkload().isInstance(notification.getNotifier())) {
-            this.syncClosedWorkload(notification);
+        if (UsagemodelPackage.eINSTANCE.getClosedWorkload().isInstance(notification.getNotifier())
+                && notification.getFeature() == UsagemodelPackage.eINSTANCE.getClosedWorkload_Population()) {
+            this.syncClosedWorkloadPopulationChange(notification);
+        } else if (CorePackage.eINSTANCE.getPCMRandomVariable().isInstance(notification.getNotifier())
+                && ((EObject) notification.getNotifier()).eContainer() instanceof ClosedWorkload
+                && notification.getFeature() == StoexPackage.eINSTANCE.getRandomVariable_Specification()) {
+            this.syncClosedWorkloadThinkTimeChange(notification);
         } else if (CorePackage.eINSTANCE.getPCMRandomVariable().isInstance(notification.getNotifier())
                 && ((EObject) notification.getNotifier()).eContainer() instanceof OpenWorkload
                 && notification.getFeature() == StoexPackage.eINSTANCE.getRandomVariable_Specification()) {
-            this.syncOpenWorkload(notification);
+            this.syncOpenWorkloadInterarrivalTimeChange(notification);
         } else if (CorePackage.eINSTANCE.getPCMRandomVariable().isInstance(notification.getNotifier())
                 && ParameterPackage.eINSTANCE.getVariableCharacterisation()
                         .isInstance(((EObject) notification.getNotifier()).eContainer())) {
@@ -74,38 +79,43 @@ public class UsageModelSyncer extends AbstractUsageModelObserver {
         }
     }
 
-    /**
-     * @param notification
-     */
-    private void syncClosedWorkload(final Notification notification) {
+    private void syncClosedWorkloadPopulationChange(final Notification notification) {
         final ClosedWorkload workload = (ClosedWorkload) notification.getNotifier();
-        this.closedWorkloadPopulationChanged(workload, notification.getNewIntValue());
+        this.closedWorkloadPopulationChange(workload, notification.getNewIntValue());
     }
 
-    /**
-     * @param notification
-     */
-    private void syncOpenWorkload(final Notification notification) {
+    private void syncClosedWorkloadThinkTimeChange(final Notification notification) {
+        final ClosedWorkload workload = (ClosedWorkload) ((EObject) notification.getNotifier()).eContainer();
+        this.closedWorkloadThinkTimeChange(workload, notification.getNewStringValue());
+    }
+
+    private void syncOpenWorkloadInterarrivalTimeChange(final Notification notification) {
         final OpenWorkload workload = (OpenWorkload) ((EObject) notification.getNotifier()).eContainer();
-        this.openWorkloadInterarrivalChange(workload, notification.getNewStringValue());
+        this.openWorkloadInterarrivalTimeChange(workload, notification.getNewStringValue());
     }
 
-    private void openWorkloadInterarrivalChange(final Workload workload, final String newInterarrivalTime) {
+    private void openWorkloadInterarrivalTimeChange(final Workload workload, final String newInterarrivalTime) {
         LOGGER.debug("Setting open workload interarrival time to " + newInterarrivalTime);
         this.runtimeModel.getUsageModels().getOpenWorkloadDriver((OpenWorkload) workload)
                 .setInterarrivalTime(newInterarrivalTime);
     }
 
-    private void closedWorkloadPopulationChanged(final Workload workload, final int newPopulation) {
+    private void closedWorkloadPopulationChange(final Workload workload, final int newPopulation) {
         LOGGER.debug("Setting closed workload population to " + newPopulation);
         this.runtimeModel.getUsageModels().getClosedWorkloadDriver((ClosedWorkload) workload)
                 .setPopulation(newPopulation);
     }
-    
+
+    private void closedWorkloadThinkTimeChange(final Workload workload, final String newThinkTime) {
+        LOGGER.debug("Setting closed workload think time to " + newThinkTime);
+        this.runtimeModel.getUsageModels().getClosedWorkloadDriver((ClosedWorkload) workload)
+                .setThinkTime(newThinkTime);
+    }
+
     private void syncUsageScenarioAddition(Notification notification) {
         LOGGER.debug("Initializing execution of new usage scenario");
-        IWorkloadDriver newDriver =
-                this.runtimeModel.getUsageModels().createAndAddWorkloadDriver((UsageScenario) notification.getNewValue());
+        IWorkloadDriver newDriver = this.runtimeModel.getUsageModels()
+                .createAndAddWorkloadDriver((UsageScenario) notification.getNewValue());
         newDriver.run();
         this.runtimeModel.getModel().getUsageScenarios().add(newDriver);
         LOGGER.debug("Execution of new usage scenario started");

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/UsageModelSyncer.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/UsageModelSyncer.java
@@ -22,30 +22,30 @@ public class UsageModelSyncer extends AbstractUsageModelObserver {
     public UsageModelSyncer() {
         super();
     }
-    
+
     @Override
     protected void add(Notification notification) {
         if (UsagemodelPackage.eINSTANCE.getUsageModel().isInstance(notification.getNotifier())
-                && UsagemodelPackage.eINSTANCE.getUsageModel_UsageScenario_UsageModel().equals(notification.getFeature())) {
+                && UsagemodelPackage.eINSTANCE.getUsageModel_UsageScenario_UsageModel()
+                        .equals(notification.getFeature())) {
             this.syncUsageScenarioAddition(notification);
         } else {
             LOGGER.error(
                     "Usage model changed...But no resync strategy is known. Simulation results most likely are wrong.");
         }
     }
-    
+
     @Override
     protected void remove(Notification notification) {
         if (UsagemodelPackage.eINSTANCE.getUsageModel().isInstance(notification.getNotifier())
-                && UsagemodelPackage.eINSTANCE.getUsageModel_UsageScenario_UsageModel().equals(notification.getFeature())) {
+                && UsagemodelPackage.eINSTANCE.getUsageModel_UsageScenario_UsageModel()
+                        .equals(notification.getFeature())) {
             this.syncUsageScenarioRemoval(notification);
         } else {
             LOGGER.error(
                     "Usage model changed...But no resync strategy is known. Simulation results most likely are wrong.");
         }
     }
-
-
 
     @Override
     protected void set(final Notification notification) {
@@ -64,7 +64,7 @@ public class UsageModelSyncer extends AbstractUsageModelObserver {
              */
         } else if (UsagemodelPackage.eINSTANCE.getUsageScenario().isInstance(notification.getNotifier())
                 && notification.getFeature() == UsagemodelPackage.eINSTANCE.getUsageScenario_UsageModel_UsageScenario()
-                && notification.getOldValue() != null && notification.getNewValue() == null){
+                && notification.getOldValue() != null && notification.getNewValue() == null) {
             /*
              * Do nothing as the change is handled as a remove on the container
              */
@@ -110,7 +110,7 @@ public class UsageModelSyncer extends AbstractUsageModelObserver {
         this.runtimeModel.getModel().getUsageScenarios().add(newDriver);
         LOGGER.debug("Execution of new usage scenario started");
     }
-    
+
     private void syncUsageScenarioRemoval(Notification notification) {
         LOGGER.debug("Stopping execution of specific usage scenario");
         ICancellableWorkloadDriver driver = this.runtimeModel.getUsageModels()

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/usagemodel/SimulatedUsageModels.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/usagemodel/SimulatedUsageModels.java
@@ -18,6 +18,7 @@ import org.palladiosimulator.simulizar.interpreter.UsageScenarioSwitch;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
 import de.uka.ipd.sdq.simucomframework.usage.ClosedWorkloadUserFactory;
 import de.uka.ipd.sdq.simucomframework.usage.ICancellableWorkloadDriver;
+import de.uka.ipd.sdq.simucomframework.usage.IClosedWorkloadUserFactory;
 import de.uka.ipd.sdq.simucomframework.usage.IScenarioRunner;
 import de.uka.ipd.sdq.simucomframework.usage.IUserFactory;
 import de.uka.ipd.sdq.simucomframework.usage.IWorkloadDriver;
@@ -77,7 +78,7 @@ public class SimulatedUsageModels {
         }
         final ClosedWorkload closedWorkload = (ClosedWorkload) workload;
 
-        final IUserFactory userFactory = new ClosedWorkloadUserFactory(this.rootContext.getModel(),
+        final IClosedWorkloadUserFactory userFactory = new ClosedWorkloadUserFactory(this.rootContext.getModel(),
                 closedWorkload.getThinkTime_ClosedWorkload().getSpecification(), usageScenario) {
 
             @Override


### PR DESCRIPTION
Depends on PalladioSimulator/Palladio-Analyzer-SimuCom#2 and synchronizes changes in the think time of closed workloads. I renamed some existing private methods to make sure that it is clear what exactly is propagated.

Again, separate cleanup (bb0c7de) and implementation (0ce4b12)