### PR TITLE
Fix wrong assumption concerning AllocationContexts

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/AllocationLookupSyncer.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/AllocationLookupSyncer.java
@@ -87,10 +87,7 @@ public class AllocationLookupSyncer extends AbstractModelObserver<Allocation>
      * @param allocation the Allocation model
      */
     protected void addInitialAllocations(Allocation allocation) {
-        for (var ctx : allocation.getAllocationContexts_Allocation()) {
-            simulatedContainerStorage.put(ctx.getAssemblyContext_AllocationContext().getId(),
-                    resourceContainerAccess.getSimulatedEntity(ctx.getResourceContainer_AllocationContext()));
-        }
+        allocation.getAllocationContexts_Allocation().forEach(this::doAddAllocationContext);
     }
 
     /**
@@ -192,15 +189,20 @@ public class AllocationLookupSyncer extends AbstractModelObserver<Allocation>
      * Convenience method to add the provided allocation context.
      */
     private void doAddAllocationContext(AllocationContext ctx) {
-        addAssemblyAllocation(ctx.getAssemblyContext_AllocationContext(), Collections.emptyList(),
-                resourceContainerAccess.getSimulatedEntity(ctx.getResourceContainer_AllocationContext()));
+        if (ctx.getAssemblyContext_AllocationContext() != null) {
+            addAssemblyAllocation(ctx.getAssemblyContext_AllocationContext(), Collections.emptyList(),
+                    resourceContainerAccess.getSimulatedEntity(ctx.getResourceContainer_AllocationContext()));    
+        }
+        
     }
 
     /**
      * Convenience method to remove the provided allocation context.
      */
     private void doRemoveAllocationContext(AllocationContext ctx) {
-        removeAssemblyAllocation(ctx.getAssemblyContext_AllocationContext(), Collections.emptyList());
+        if (ctx.getAssemblyContext_AllocationContext() != null) {
+            removeAssemblyAllocation(ctx.getAssemblyContext_AllocationContext(), Collections.emptyList());
+        }
     }
 
     /**

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/AllocationLookupSyncer.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/modelobserver/AllocationLookupSyncer.java
@@ -192,8 +192,7 @@ public class AllocationLookupSyncer extends AbstractModelObserver<Allocation>
         if (ctx.getAssemblyContext_AllocationContext() != null) {
             addAssemblyAllocation(ctx.getAssemblyContext_AllocationContext(), Collections.emptyList(),
                     resourceContainerAccess.getSimulatedEntity(ctx.getResourceContainer_AllocationContext()));    
-        }
-        
+        } 
     }
 
     /**


### PR DESCRIPTION
I assumed AllocationContexts only allocation Assemblies. This was wrong. Nevertheless, we only track AssemblyContexts here.