### PR TITLE
make RepositoryComponentSwitch class public and therefore usable from…

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RepositoryComponentSwitch.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RepositoryComponentSwitch.java
@@ -44,7 +44,7 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
  * @author snowball
  *
  */
-class RepositoryComponentSwitch extends RepositorySwitch<SimulatedStackframe<Object>> {
+public class RepositoryComponentSwitch extends RepositorySwitch<SimulatedStackframe<Object>> {
 
     private static final Logger LOGGER = Logger.getLogger(RepositoryComponentSwitch.class);
     public static final AssemblyContext SYSTEM_ASSEMBLY_CONTEXT = CompositionFactory.eINSTANCE.createAssemblyContext();


### PR DESCRIPTION
… outside (e.g. other plugins)