### PR TITLE
Switch to release version of Tycho 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,17 +12,9 @@
 	<artifactId>parent</artifactId>	
 	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>tycho-staged</id>
-			<url>https://oss.sonatype.org/content/repositories/orgeclipsetycho-1062/</url>
-		</pluginRepository>
-	</pluginRepositories>
 	
 	<properties>
 		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.simulizar.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
-		<tycho.version>1.7.0</tycho.version>
 	</properties>
 	
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.4.4</version>
+		<version>0.4.5</version>
 	</parent>
 	<groupId>org.palladiosimulator.simulizar</groupId>
 	<artifactId>parent</artifactId>	


### PR DESCRIPTION
Tycho 1.7.0 was released. Hence, we can switch back to the release version.