### PR TITLE
Removed obsolete tp entry for release profile.

### DIFF
--- a/releng/org.palladiosimulator.simulizar.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.simulizar.targetplatform/tp.target
@@ -242,11 +242,6 @@
 						<unit id="org.palladiosimulator.experimentanalysis.tests.feature.feature.group" version="tbd"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-experimentanalysis/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.mockito.junit.jupiter.feature.feature.group" version="tbd"/>
-			<unit id="org.hamcrest.feature.feature.group" version="tbd"/>
-			<repository location="https://updatesite.mdsd.tools/thirdparty-library/releases/latest/"/>
-		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
 			<unit id="org.mockito.core-with-junit-extension.feature.feature.group" version="tbd"/>
 			<unit id="net.bytebuddy.byte-buddy.feature.feature.group" version="tbd"/>


### PR DESCRIPTION
There are two entries for the thirdparty update site with filter `release`. The one that I removed has been replaced by another entry and is obsolete. However, it breaks release builds and has to be removed.