### PR TITLE
refactoring; use renamed member variable forkContext

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RDSeffSwitch.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/RDSeffSwitch.java
@@ -496,7 +496,7 @@ class RDSeffSwitch extends SeffSwitch<Object> implements IComposableSwitch {
                      * reasons we need an InterpreterDefaultContext. Thus we have to copy the
                      * context including its stack.
                      */
-                    final InterpreterDefaultContext seffContext = new InterpreterDefaultContext(this.myContext,
+                    final InterpreterDefaultContext seffContext = new InterpreterDefaultContext(this.forkContext,
                             RDSeffSwitch.this.context.getRuntimeState(), true,
                             RDSeffSwitch.this.context.getLocalPCMModelAtContextCreation());
                     seffContext.getAssemblyContextStack().addAll(parentAssemblyContextStack);


### PR DESCRIPTION
Please review. SimuCom changes must be merged first because I renamed the member variable myContext in ForkedBehaviourProcess to forkContext; this member variable is references in Simulizar in the RDSeffSwitch when creating the InterpreterDefaultContext; thus the Jenkins build of this PR currently fails with a compile error.