### PR TITLE
Deactivate branch deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
 PalladioPipeline {
     deployUpdatesite 'releng/org.palladiosimulator.simulizar.updatesite/target/repository'
-    skipDeploy false
 }


### PR DESCRIPTION
The branch deployment flag got into the master branch by mistake.