### PR TITLE
Fix wrong calculator binding

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/di/modules/scoped/runtime/LinkingResourceSimulationModule.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/di/modules/scoped/runtime/LinkingResourceSimulationModule.java
@@ -33,7 +33,7 @@ public interface LinkingResourceSimulationModule {
             SimuLizarWorkflowConfiguration config, Lazy<NoDemandCalculator> noDemand,
             Lazy<MiddlewareCompletionAwareDemandCalculator> middlewareAware,
             Lazy<StackFrameBytesizeAccumulatingDemandCalculator> stackAccumulating) {
-        if (config.getSimulateFailures())
+        if (config.getSimulateLinkingResources())
             return middlewareAware.get();
         else if (config.getSimulateThroughputOfLinkingResources())
             return stackAccumulating.get();


### PR DESCRIPTION
When selecting the appropriate network demand calculator, the wrong property was checked. This PR fixes that.