### PR TITLE
[SIMULIZAR-167] Generate monitors for passive resources by default

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/launcher/jobs/extensions/DefaultMeasuringPointRepositoryFactory.xtend
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/launcher/jobs/extensions/DefaultMeasuringPointRepositoryFactory.xtend
@@ -12,6 +12,8 @@ import org.palladiosimulator.pcm.system.System
 import org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall
 import org.palladiosimulator.pcm.usagemodel.UsageScenario
 import org.palladiosimulator.pcmmeasuringpoint.PcmmeasuringpointFactory
+import org.palladiosimulator.pcm.core.composition.AssemblyContext
+import org.palladiosimulator.pcm.repository.BasicComponent
 
 class DefaultMeasuringPointRepositoryFactory {
 	static val mf = MeasuringpointFactory.eINSTANCE;
@@ -50,6 +52,19 @@ class DefaultMeasuringPointRepositoryFactory {
 		repository.measuringPoints += pmf.createEntryLevelSystemCallMeasuringPoint => [
 			entryLevelSystemCall = call
 		]
+	}
+	
+	static def dispatch createMeasuringPoint(AssemblyContext context, MeasuringPointRepository repository) {
+		val component = context.encapsulatedComponent__AssemblyContext
+		if (component instanceof BasicComponent) {
+			component.passiveResource_BasicComponent.forEach[res |
+				repository.measuringPoints += pmf.createAssemblyPassiveResourceMeasuringPoint => [
+					assembly = context
+					passiveResource = res
+				]	
+			]
+		}
+		
 	}
 	
 	static def dispatch createMeasuringPoint(System sys, MeasuringPointRepository repository) {

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/launcher/jobs/extensions/DefaultMonitorRepositoryFactory.xtend
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/launcher/jobs/extensions/DefaultMonitorRepositoryFactory.xtend
@@ -9,6 +9,7 @@ import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint
 import org.palladiosimulator.pcmmeasuringpoint.ExternalCallActionMeasuringPoint
 import org.palladiosimulator.pcmmeasuringpoint.SystemOperationMeasuringPoint
 import org.palladiosimulator.pcmmeasuringpoint.UsageScenarioMeasuringPoint
+import org.palladiosimulator.pcmmeasuringpoint.AssemblyPassiveResourceMeasuringPoint
 
 class DefaultMonitorRepositoryFactory {
 	static val mf = MonitorRepositoryFactory.eINSTANCE
@@ -72,4 +73,24 @@ class DefaultMonitorRepositoryFactory {
 		]
 	}
 	
+	static def dispatch createDefaultMonitors(AssemblyPassiveResourceMeasuringPoint p, MonitorRepository repo) {
+		repo.monitors += mf.createMonitor => [
+			measuringPoint = p
+			measurementSpecifications += mf.createMeasurementSpecification => [
+				metricDescription = MetricDescriptionConstants.WAITING_TIME_METRIC
+				triggersSelfAdaptations = false
+				processingType = mf.createFeedThrough
+			]
+			measurementSpecifications += mf.createMeasurementSpecification => [
+				metricDescription = MetricDescriptionConstants.HOLDING_TIME_METRIC
+				triggersSelfAdaptations = false
+				processingType = mf.createFeedThrough
+			]
+			measurementSpecifications += mf.createMeasurementSpecification => [
+				metricDescription = MetricDescriptionConstants.STATE_OF_PASSIVE_RESOURCE_METRIC
+				triggersSelfAdaptations = false
+				processingType = mf.createFeedThrough
+			]
+		]
+	}
 }

--- a/tests/org.palladiosimulator.simulizar.tests/src/org/palladiosimulator/simulizar/simulation/tests/AcquireReleaseExample.java
+++ b/tests/org.palladiosimulator.simulizar.tests/src/org/palladiosimulator/simulizar/simulation/tests/AcquireReleaseExample.java
@@ -1,0 +1,91 @@
+package org.palladiosimulator.simulizar.simulation.tests;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.palladiosimulator.simulizar.test.commons.hamcrest.Matchers.firstMeasurementMatchesDifferentlyThanTheRest;
+
+import javax.measure.unit.SI;
+import javax.measure.unit.Unit;
+
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.edp2.models.ExperimentData.ExperimentRun;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.pcm.repository.PassiveResource;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.usagemodel.UsageScenario;
+import org.palladiosimulator.simulizar.test.commons.annotation.LoadPCMInstanceFromBundle;
+import org.palladiosimulator.simulizar.test.commons.annotation.RunSimuLizar;
+import org.palladiosimulator.simulizar.test.commons.annotation.SimulationConfig;
+import org.palladiosimulator.simulizar.test.commons.util.MeasurementTestUtils;
+
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import tools.mdsd.junit5utils.annotations.PluginTestOnly;
+
+@PluginTestOnly
+class AcquireReleaseExample {
+
+    /**
+     * This test runs and validates the results as described in the manual test case SIMULIZAR-109.
+     */
+    @Test
+    @LoadPCMInstanceFromBundle(bundleName = "org.palladiosimulator.examples.package", basePath = "initiatorTemplates/Acquire_Example", modelFiles = {
+            "AllocationExample.allocation", "AquireExample.usagemodel" })
+    @SimulationConfig(maxMeasurements = "10")
+    @RunSimuLizar
+    void testAcquireReleaseExample(PassiveResource pResource, ProcessingResourceSpecification aCPU, UsageScenario scenario, ExperimentRun expRun)
+            throws JobFailedException, UserCanceledException {
+        // Test step 5
+        // The response time of the first four requests should be 10, 20, 30, and 40. Then, the response time should be constant at 50.
+        var usageScenarioMeasurement = MeasurementTestUtils.getMeasurementOfAt(expRun.getMeasurement(), 
+                MetricDescriptionConstants.RESPONSE_TIME_METRIC_TUPLE, scenario);
+        assertTrue(usageScenarioMeasurement.isPresent());
+        
+        MeasurementTestUtils.allDoubleMeasurementValuesMatch(usageScenarioMeasurement.get(),
+                MetricDescriptionConstants.RESPONSE_TIME_METRIC, SI.SECOND,
+                firstMeasurementMatchesDifferentlyThanTheRest(closeTo(10.0, 0.001), 
+                    firstMeasurementMatchesDifferentlyThanTheRest(closeTo(20.0, 0.001), 
+                        firstMeasurementMatchesDifferentlyThanTheRest(closeTo(30.0, 0.001), 
+                            firstMeasurementMatchesDifferentlyThanTheRest(closeTo(40.0, 0.001), 
+                                    closeTo(50.0, 0.001))))));
+        
+        // Test step 6
+        // The utilization of CPU should be 100% with 1 job.
+        var soarMeasurement = MeasurementTestUtils.getMeasurementOfAt(expRun.getMeasurement(),
+                MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC_TUPLE, aCPU);
+        assertTrue(soarMeasurement.isPresent());
+        var buckets = MeasurementTestUtils.calculateIntBucketsBasedOnStateDuration(soarMeasurement.get(),
+                MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC, Unit.ONE);
+        assertThat(buckets.get(0), is(closeTo(0.0, 0.01)));
+        var bucketSum = buckets.entrySet().stream().filter(e -> e.getKey() != 0).mapToDouble(e -> e.getValue()).sum();
+        assertThat(bucketSum, is(closeTo(100.0, 0.1)));
+        
+        // Test step 7
+        // The utilization should be 100% with the state "0", meaning no resource is available.
+        var soprMeasurement = MeasurementTestUtils.getMeasurementOfAt(expRun.getMeasurement(),
+                MetricDescriptionConstants.STATE_OF_PASSIVE_RESOURCE_METRIC_TUPLE, pResource);
+        assertTrue(soprMeasurement.isPresent());
+        buckets = MeasurementTestUtils.calculateIntBucketsBasedOnStateDuration(soprMeasurement.get(),
+                MetricDescriptionConstants.STATE_OF_PASSIVE_RESOURCE_METRIC, Unit.ONE);
+        assertThat(buckets.get(0), is(closeTo(100.0, 0.01)));
+        bucketSum = buckets.entrySet().stream().filter(e -> e.getKey() != 0).mapToDouble(e -> e.getValue()).sum();
+        assertThat(bucketSum, is(closeTo(0.0, 0.1)));
+        
+        // Test step 8
+        // The wait time of the first four requests should be 0, 10, 20, and 30. Then, the wait time should be constant at 40.
+        var waitingTimeMeasurement = expRun.getMeasurement().stream().filter(m -> m.getMeasuringType().getMetric().getId().equals(
+                MetricDescriptionConstants.WAITING_TIME_METRIC_TUPLE.getId())).findAny();
+        assertTrue(waitingTimeMeasurement.isPresent());
+        MeasurementTestUtils.allDoubleMeasurementValuesMatch(waitingTimeMeasurement.get(),
+                MetricDescriptionConstants.WAITING_TIME_METRIC, SI.SECOND,
+                firstMeasurementMatchesDifferentlyThanTheRest(closeTo(0.0, 0.001), 
+                    firstMeasurementMatchesDifferentlyThanTheRest(closeTo(10.0, 0.001), 
+                        firstMeasurementMatchesDifferentlyThanTheRest(closeTo(20.0, 0.001), 
+                            firstMeasurementMatchesDifferentlyThanTheRest(closeTo(30.0, 0.001), 
+                                    closeTo(40.0, 0.001))))));
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes [SIMULIZAR-167](https://palladio-simulator.atlassian.net/browse/SIMULIZAR-167). It adds the metrics Holding Time, Waiting Time and State Of Passive Resource to the default set of monitors generated for each passive resource, if no dedicated monitor repository is provided. 

Furthermore, this PR adds the automatic execution of test case [SIMULIZAR-109](https://palladio-simulator.atlassian.net/browse/SIMULIZAR-109) to the set of simulation test cases.