### PR TITLE
Fix for Simulizar-170

### DIFF
--- a/features/org.palladiosimulator.simulizar.feature/feature.xml
+++ b/features/org.palladiosimulator.simulizar.feature/feature.xml
@@ -261,4 +261,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.palladiosimulator.simulizar.events"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This includes the Simulizar Event Modelling Support in the default PCM bench release.