### PR TITLE
Follow-up patch for fix to SIMULIZAR-170

### DIFF
--- a/bundles/org.palladiosimulator.simulizar.events/build.properties
+++ b/bundles/org.palladiosimulator.simulizar.events/build.properties
@@ -3,4 +3,11 @@ source.. = src/,\
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               icons/
+src.includes = META-INF/,\
+               build.properties,\
+               icons/,\
+               plugin.xml,\
+               src/,\
+               src-gen/


### PR DESCRIPTION
Fixed the missing icon resource in the binary plugin built. Fixed the source built too.